### PR TITLE
Split compiler flags by whitespace.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,9 +19,9 @@ def conditional_decode( string ):
       return string
   return string.decode( 'utf-8' )
 
-polymake_cflags = conditional_decode( subprocess.check_output( [ "polymake-config", "--cflags" ] ).strip() ).split(' ')
-polymake_cflags += conditional_decode( subprocess.check_output( [ "polymake-config", "--includes" ] ).strip() ).split(' ')
-polymake_ldflags = conditional_decode( subprocess.check_output( [ "polymake-config", "--ldflags" ] ).strip() ).split(' ')
+polymake_cflags = conditional_decode( subprocess.check_output( [ "polymake-config", "--cflags" ] ).strip() ).split()
+polymake_cflags += conditional_decode( subprocess.check_output( [ "polymake-config", "--includes" ] ).strip() ).split()
+polymake_ldflags = conditional_decode( subprocess.check_output( [ "polymake-config", "--ldflags" ] ).strip() ).split()
 polymake_ldflags += [ "-lpolymake" ]
 
 polymake_cc = conditional_decode( subprocess.check_output( [ "polymake-config", "--cc" ] ).strip() )


### PR DESCRIPTION
Previously setup.py splits compiler flags by a single whitespace, which causes build failures when there are two space characters, causing an extra empty string being added to the compiler command line.

In my case, `polymake-config --cflags` returned a string with two space characters before the last compiler flag:

```bash
-DPOLYMAKE_VERSION=409 -fPIC -pipe -march=rv64gc -mabi=lp64d -O2 -pipe -fno-plt -fexceptions -Wp,-D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security -fstack-clash-protection -Wp,-D_GLIBCXX_ASSERTIONS -g -ffile-prefix-map=/build/polymake/src=/usr/src/debug/polymake -flto=auto -std=c++14 -ftemplate-depth-200 -fno-strict-aliasing -fopenmp -Wshadow -Wlogical-op -Wconversion -Wzero-as-null-pointer-constant -Wno-parentheses -Wno-error=unused-function -Wno-stringop-overflow -Wno-array-bounds -Wno-maybe-uninitialized -Wno-free-nonheap-object -DPOLYMAKE_WITH_FLINT  -DPOLYMAKE_DEBUG=0
```

An extra empty string got passed to the compiler and it caused a cryptic error.

```
g++: warning: : linker input file unused because linking not done
g++: error: : linker input file not found: No such file or directory
```